### PR TITLE
Add board size dropdown and improve grid layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,12 @@
     <button onclick="generatePuzzle('easy')">Easy</button>
     <button onclick="generatePuzzle('medium')">Medium</button>
     <button onclick="generatePuzzle('hard')">Hard</button>
+    <label for="sizeSelect">Size:</label>
+    <select id="sizeSelect">
+      <option value="6">6x6</option>
+      <option value="8">8x8</option>
+      <option value="10">10x10</option>
+    </select>
   </div>
 
   <div id="board"></div>

--- a/script.js
+++ b/script.js
@@ -1,10 +1,23 @@
 const boardElem = document.getElementById("board");
-const boardSize = 6;
+const sizeSelect = document.getElementById("sizeSelect");
+let boardSize = parseInt(sizeSelect.value, 10);
+
+function emptyBoard(size) {
+  const board = [];
+  for (let r = 0; r < size; r++) {
+    board.push(Array(size).fill(""));
+  }
+  return board;
+}
 
 function generatePuzzle(difficulty) {
-  const puzzle = PUZZLES[difficulty];
+  boardSize = parseInt(sizeSelect.value, 10);
+  let puzzle = PUZZLES[difficulty];
+  if (!puzzle || puzzle.length !== boardSize) {
+    puzzle = emptyBoard(boardSize);
+  }
   boardElem.innerHTML = "";
-  boardElem.style.gridTemplateColumns = `repeat(${boardSize}, 1fr)`;
+  boardElem.style.gridTemplateColumns = `repeat(${boardSize}, 48px)`;
 
   for (let r = 0; r < boardSize; r++) {
     for (let c = 0; c < boardSize; c++) {


### PR DESCRIPTION
## Summary
- allow selecting board size with a dropdown
- generate blank boards when a puzzle size isn't defined
- fix grid layout by using fixed pixel columns

## Testing
- `npm test` *(fails: missing package.json)*

------