### PR TITLE
Disable double-tap zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,10 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+  />
   <title>Myosu - The Logic of Stones</title>
   <link rel="stylesheet" href="style.css" />
   <link rel="icon" href="favicon.ico" />

--- a/style.css
+++ b/style.css
@@ -36,6 +36,7 @@ button {
   justify-content: center;
   gap: 4px;
   margin: 1rem auto;
+  touch-action: manipulation;
 }
 
 .cell {


### PR DESCRIPTION
## Summary
- prevent zooming on mobile by adding a viewport tag with `user-scalable=no`
- stop mobile browsers from zooming when the board is double-tapped

## Testing
- `git status --short`

------