### PR TITLE
Fix board layout on mobile

### DIFF
--- a/script.js
+++ b/script.js
@@ -211,7 +211,12 @@ function createDifficultyBoards(full, removed) {
 function renderBoard(board) {
   const size = board.length;
   boardElem.innerHTML = "";
-  boardElem.style.gridTemplateColumns = `repeat(${size}, 48px)`;
+  const maxBoard = Math.min(window.innerWidth, window.innerHeight) * 0.9;
+  const cellSize = Math.floor(maxBoard / size);
+  const boardSize = cellSize * size;
+  boardElem.style.width = boardSize + "px";
+  boardElem.style.height = boardSize + "px";
+  boardElem.style.gridTemplateColumns = `repeat(${size}, ${cellSize}px)`;
   for (let r = 0; r < size; r++) {
     for (let c = 0; c < size; c++) {
       const cell = document.createElement("div");
@@ -221,6 +226,10 @@ function renderBoard(board) {
         cell.textContent = val;
         cell.dataset.fixed = "true";
       }
+      cell.style.width = cellSize + "px";
+      cell.style.height = cellSize + "px";
+      cell.style.lineHeight = cellSize + "px";
+      cell.style.fontSize = Math.floor(cellSize * 0.6) + "px";
       cell.onclick = () => {
         if (!cell.dataset.fixed) {
           if (cell.textContent === "") {

--- a/style.css
+++ b/style.css
@@ -37,17 +37,19 @@ button {
   gap: 4px;
   margin: 1rem auto;
   touch-action: manipulation;
+  width: min(90vmin, 480px);
+  height: min(90vmin, 480px);
 }
 
 .cell {
-  width: 48px;
-  height: 48px;
-  font-size: 28px;
   background: #eee;
   border: 1px solid #ccc;
-  line-height: 48px;
   cursor: pointer;
   user-select: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
 }
 
 #rules {


### PR DESCRIPTION
## Summary
- size board dynamically so 10x10 fits mobile screens
- remove fixed cell dimensions in CSS and let JS set them responsively

## Testing
- `npm test` *(fails: ENOENT: no such file or directory)*

------
