### PR TITLE
Prevent rules text overlapping board

### DIFF
--- a/style.css
+++ b/style.css
@@ -35,7 +35,8 @@ button {
   display: grid;
   justify-content: center;
   gap: 4px;
-  margin: 1rem auto;
+  /* Add extra bottom margin so the rules don't overlap the board, especially on phones */
+  margin: 1rem auto 6rem;
   touch-action: manipulation;
   width: min(90vmin, 480px);
   height: min(90vmin, 480px);


### PR DESCRIPTION
## Summary
- add extra bottom margin under the board to keep the How to Play rules from overlapping it, especially on phones

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e8b5b3388832183f0c328bc13038a